### PR TITLE
Feat/type safety zod

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3,6 +3,9 @@
   "workspaces": {
     "": {
       "name": "tsuki",
+      "dependencies": {
+        "zod": "^3.24.4",
+      },
       "devDependencies": {
         "@eslint/js": "^9.26.0",
         "@types/bun": "latest",

--- a/example/index.ts
+++ b/example/index.ts
@@ -1,7 +1,33 @@
+import { z } from 'zod';
 import { Tsuki } from '../src/core/tsuki';
+import type { Context } from '../src/core/context';
+
+const userSchema = z.object({
+  name: z.string(),
+  age: z.number(),
+  email: z.string().email(),
+  username: z.string().min(3).max(20),
+})
+
+const loginHandler = (c: Context) => {
+  return c.json({ message: 'Login successful!', data: c.body });
+}
+
+const loginSchema = z.object({
+  username: z.string().min(3).max(20),
+  password: z.string().min(8).max(20),
+})
 
 const app = new Tsuki();
-app.get('/hello', (c) => new Response('Hello World!'));
+app.get('/hello', () => new Response('Hello World!'));
 app.get('/json', (c) => c.json({ message: 'Hello World!' }));
 app.get('/text', (c) => c.text('this is a text response'));
+app.post('/user', userSchema, (c) => {
+    console.log('user data: ', c.body);
+    
+    return c.json({ message: 'User created successfully!', data: c.body });
+})
+
+app.post('/login', loginSchema, loginHandler);
+
 app.serve(3000);

--- a/example/index.ts
+++ b/example/index.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { Tsuki } from '../src/core/tsuki';
+import type { Context } from '../src/core/context';
 
 const userSchema = z.object({
   name: z.string(),
@@ -13,6 +14,10 @@ const loginSchema = z.object({
   password: z.string().min(8).max(20),
 })
 
+const loginHandler = (c:Context<z.infer<typeof loginSchema>>) => {
+  return c.json({ message: 'Login successful!', data: c.body });
+}
+
 const app = new Tsuki();
 app.get('/hello', () => new Response('Hello World!'));
 app.get('/json', (c) => c.json({ message: 'Hello World!' }));
@@ -23,8 +28,6 @@ app.post('/user', userSchema, (c) => {
     return c.json({ message: 'User created successfully!', data: c.body });
 })
 
-app.post('/login', loginSchema, (c) => {
-  return c.json({ message: 'Login successful!', data: c.body });
-});
+app.post('/login', loginSchema, loginHandler);
 
 app.serve(3000);

--- a/example/index.ts
+++ b/example/index.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod';
 import { Tsuki } from '../src/core/tsuki';
-import type { Context } from '../src/core/context';
 
 const userSchema = z.object({
   name: z.string(),
@@ -8,10 +7,6 @@ const userSchema = z.object({
   email: z.string().email(),
   username: z.string().min(3).max(20),
 })
-
-const loginHandler = (c: Context) => {
-  return c.json({ message: 'Login successful!', data: c.body });
-}
 
 const loginSchema = z.object({
   username: z.string().min(3).max(20),
@@ -28,6 +23,8 @@ app.post('/user', userSchema, (c) => {
     return c.json({ message: 'User created successfully!', data: c.body });
 })
 
-app.post('/login', loginSchema, loginHandler);
+app.post('/login', loginSchema, (c) => {
+  return c.json({ message: 'Login successful!', data: c.body });
+});
 
 app.serve(3000);

--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
   },
   "peerDependencies": {
     "typescript": "^5.8.3"
+  },
+  "dependencies": {
+    "zod": "^3.24.4"
   }
 }

--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -1,7 +1,7 @@
-export interface Context<T = unknown> {
+export interface Context<B = unknown> {
   req: Request;
   params: Record<string, string>;
-  body?: T;
+  body: B;
 
   text: (body: string, status?: number) => Response;
   json: <R>(body: R, status?: number) => Response;

--- a/src/core/tsuki.ts
+++ b/src/core/tsuki.ts
@@ -1,3 +1,4 @@
+import type { z, ZodObject, ZodRawShape } from 'zod';
 import type { HttpMethodType } from '../types';
 import type { Context } from './context';
 import { Router, type RouteHandler } from './router';
@@ -5,7 +6,7 @@ import { Router, type RouteHandler } from './router';
 export class Tsuki {
   private router: Router = new Router();
 
-  private createContext(req: Request): Context {
+  private createContext<T = unknown>(req: Request): Context<T> {
     const text = (body: string, status = 200) => {
       return new Response(body, {
         status,
@@ -19,9 +20,10 @@ export class Tsuki {
         headers: { 'Content-Type': 'application/json' },
       });
     };
-    const ctx: Context = { req, params: {}, body: null, text, json };
 
-    return ctx;
+    const ctx = { req, params: {}, body: null, text, json };
+
+    return ctx as Context<T>;
   }
 
   get(path: string, handler: RouteHandler) {
@@ -29,24 +31,63 @@ export class Tsuki {
     return this;
   }
 
+  post<T extends ZodRawShape>(path: string, schema: ZodObject<T>,handler: RouteHandler<z.infer<ZodObject<T>>>) {
+    this.router.addRoute('POST', path, schema, handler);
+    return this;
+  }
+
+  put<T extends ZodRawShape>(path: string, schema: ZodObject<T>,handler: RouteHandler<z.infer<ZodObject<T>>>) {
+    this.router.addRoute('PUT', path, schema, handler);
+    return this;
+  }
+
+   patch<T extends ZodRawShape>(path: string, schema: ZodObject<T>,handler: RouteHandler<z.infer<ZodObject<T>>>) {
+    this.router.addRoute('PATCH', path, schema, handler);
+    return this;
+  }
+
+  delete(path: string, handler: RouteHandler) {
+    this.router.addRoute('DELETE', path, handler);
+    return this;
+  }
+
+
+
   //Running server
   serve(port: number) {
     //Bun server
     Bun.serve({
       port,
-      fetch: (req) => {
+      fetch: async (req) => {
         const url = new URL(req.url);
         const route = this.router.findRoute(
           req.method as HttpMethodType,
           url.pathname
         );
-        console.log('reached in serve: ', route);
+        // console.log('reached in serve: ', route);
 
         //If router is found then
         if (route) {
           const ctx = this.createContext(req);
 
-          return route.handler(ctx);
+          //If route has schema then validate the body
+          if(route.schema)  {
+            try {
+              if(!req.body) {
+                return new Response('Invalid request body', { status: 400 });
+              }
+              const body = await req.json();
+              console.log('body: ', body);
+              ctx.body = route.schema.parse(body);
+              
+            } catch(err) {
+              console.error('Validation error: ', err);
+              return new Response('Invalid request body', { status: 400 });
+            }
+          }
+
+       
+          return route.handler(ctx as Context<typeof ctx.body>);
         }
         return new Response('Not Found', { status: 404 });
       },

--- a/tests/core/validation.test.ts
+++ b/tests/core/validation.test.ts
@@ -1,0 +1,86 @@
+import {beforeAll, expect, describe, it} from "bun:test";
+import { Tsuki } from "../../src/core/tsuki";
+import { z } from "zod";
+
+describe("Zod Validation for Request Body", () =>{
+    beforeAll(() => {
+        const app = new Tsuki();
+
+        app.get('/hello', () => new Response('Hello World!'));
+        app.get('/json', (c) => c.json({ message: 'Hello World!' }));
+
+        const userSchema = z.object({
+            username: z.string().min(3).max(20),
+            email: z.string().email(),
+        })
+
+        app.post("/users", userSchema, (c) => {
+            return c.json({ username: c.body.username, email: c.body.email }, 201);
+        })
+
+        app.serve(3000);
+
+    })
+
+    const BASE_URL = "http://localhost:3000";
+
+
+    it("handles GET /hello", async () => {
+        const res = await fetch(`${BASE_URL}/hello`);
+        const text = await res.text();
+        expect(text).toEqual("Hello World!");
+        expect(res.status).toEqual(200);
+    })
+
+    it("handles POST /users with valid body", async() => {
+        const res = await fetch(`${BASE_URL}/users`,{
+            method:'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+                username: 'spellsaif',
+                email: 'saif@example.com'
+            })
+        })
+
+        const json = await res.json();
+
+        expect(res.status).toEqual(201);
+        expect(json).toEqual({username: 'spellsaif', email: 'saif@example.com'})
+    })
+
+    it("rejects POST /users with invalid body", async() => {
+        const res = await fetch(`${BASE_URL}/users`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+                username: "spellsaif",
+            })
+        })
+        expect(res.status).toEqual(400);
+    })
+
+    it("returns 400 for empty request body", async() => {
+        const res = await fetch(`${BASE_URL}/users`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({})
+        })
+
+        expect(res.status).toEqual(400);
+    })
+
+    it("returns 404 for unknown routes", async() => {
+        const res = await fetch(`${BASE_URL}/invalid`);
+        expect(res.status).toEqual(404);
+    })
+
+
+
+
+})

--- a/tests/core/validation.test.ts
+++ b/tests/core/validation.test.ts
@@ -18,6 +18,15 @@ describe("Zod Validation for Request Body", () =>{
             return c.json({ username: c.body.username, email: c.body.email }, 201);
         })
 
+        const songSchema = z.object({
+            title: z.string({required_error: "title of the song is required"}),
+            tags: z.array(z.string())
+        })
+
+        app.post("/songs", songSchema, (c) => {
+            return c.json({ title: c.body.title, tags: c.body.tags }, 201);
+        })
+
         app.serve(3000);
 
     })
@@ -63,13 +72,28 @@ describe("Zod Validation for Request Body", () =>{
         expect(res.status).toEqual(400);
     })
 
-    it("returns 400 for empty request body", async() => {
+    it("returns 400 for empty request body POST /users", async() => {
         const res = await fetch(`${BASE_URL}/users`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json'
             },
             body: JSON.stringify({})
+        })
+
+        expect(res.status).toEqual(400);
+    })
+
+    it("returns 400 for invalid 'tags' field POST /songs", async() => {
+        const res = await fetch(`${BASE_URL}/songs`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+                title: "They don't care about us",
+                tags: ["pop", 123]
+            })
         })
 
         expect(res.status).toEqual(400);


### PR DESCRIPTION
Zod Validation for Request Body
1. Implemented Zod Validation for Request Body
2. 'POST' 'PUT' 'PATCH' handlers can accept Zod schema for validating Request Body
3. Now c.body (Context) can infer zod schema for type-safe c.body and leverage typescript features like autocompletion, showing fields, etc.
4. Invalid Request Body throws ZodError with status 400.
5. Empty Request body will sends status 400 with error message "Invalid Request Body"
6. Implemented Generics for Context, Route, RouteHandler for type-safe Context.body
7. added schema field for Context interface
8. Added type-safe 'post' 'put' 'patch' method to Tsuki.ts
9. Tested Zod Validation for Request Body and all edge case scenarios. 